### PR TITLE
fix: yaml syntax error

### DIFF
--- a/.github/workflows/.aspect-workflows-reusable.yaml
+++ b/.github/workflows/.aspect-workflows-reusable.yaml
@@ -85,8 +85,7 @@ jobs:
       - name: ${{ fromJson(needs.setup.outputs.cfg).workflows_config[matrix.job].name }}
         uses: aspect-build/workflows-action@5.14.21
         # CORREÇÃO DE SINTAXE: O bloco 'env' é uma chave/valor YAML. A expressão precisa ser o VALOR, não a CHAVE.
-        env:
-          DYNAMIC_SECRETS: ${{ inputs.inherited_secrets != '' && fromJson(steps.process_secrets.outputs.filtered_secrets) || fromJson('{}') }}
+        env: ${{ inputs.inherited_secrets != '' && fromJson(steps.process_secrets.outputs.filtered_secrets) || fromJson('{}') }}
         timeout-minutes: ${{ fromJson(needs.setup.outputs.cfg).workflows_config[matrix.job].timeout_in_minutes }}
         with:
           workspace: ${{ fromJson(needs.setup.outputs.cfg).workflows_config[matrix.job].workspace }}


### PR DESCRIPTION
Not sure where this came in from but it's breaking the read on the file.

```
The template is not valid. writechoiceorg/node-app-js-gcp/.github/workflows/.aspect-workflows-reusable.yaml@4866aa1c5978d79f61517b13df68e2e64bdc87ce (Line: 88, Col: 28): A mapping was not expected
```

corrected back to the sample file version: https://github.com/aspect-workflows/awd-writechoice-1/blob/216bd9fdd3a7bfa4a4a3c22edc4ac50db8e030af/examples/github_actions_workflow/.github/workflows/.aspect-workflows-reusable.yaml#L122